### PR TITLE
Enhance image management and logging features

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import timedelta
 
 from src.core.image_manager import ImageManager
 from src.core.instagram import Instagram
@@ -42,10 +43,24 @@ def handle_image_management() -> None:
     image_manager = ImageManager()
 
     if prompt_yes_no("Do you want to remove small images?"):
-        image_manager.remove_small_images(min_size=(256, 256))
+        try:
+            width = int(input("Enter the minimum width: "))
+            height = int(input("Enter the minimum height: "))
+        except ValueError:
+            print("Invalid input. Please enter a number.")
+            return
 
-    if prompt_yes_no("Do you want to remove old images (more than 1 week)?"):
-        image_manager.remove_old_images()
+        min_size = (width, height)
+        image_manager.remove_small_images(min_size=min_size)
+
+    if prompt_yes_no("Do you want to remove old images?"):
+        try:
+            days = int(input("Enter the number of days: "))
+        except ValueError:
+            print("Invalid input. Please enter a number.")
+            return
+
+        image_manager.remove_old_images(timedelta(days=days))
 
 
 def handle_instagram_download() -> None:
@@ -58,6 +73,7 @@ def handle_instagram_download() -> None:
     else:
         instagram = Instagram(None)
 
+    os.system("cls" if os.name == "nt" else "clear")
     instagram.run()
 
 
@@ -67,7 +83,6 @@ def main() -> None:
     """
     setup_logging()
     logger = logging.getLogger(__name__)
-    os.system("cls" if os.name == "nt" else "clear")
 
     logger.info("Starting the application")
     handle_image_management()

--- a/src/core/image_manager.py
+++ b/src/core/image_manager.py
@@ -37,7 +37,7 @@ class ImageManager:
 
     def remove_old_images(
         self: "ImageManager",
-        cutoff_delta: timedelta = timedelta(weeks=5),
+        cutoff_delta: timedelta = timedelta(weeks=4),
     ) -> None:
         """
         Remove media files in the that are older than the specified duration.
@@ -45,7 +45,9 @@ class ImageManager:
         Args:
             cutoff_delta (timedelta): The age limit for removing files.
         """
-        self.logger.info("Starting removal of images older than %s", cutoff_delta)
+        self.logger.info(
+            "Starting removal of images older than %s days", cutoff_delta.days
+        )
         media_files = self._get_media_files()
 
         media_files = self._get_media_files()

--- a/src/core/instagram.py
+++ b/src/core/instagram.py
@@ -73,6 +73,9 @@ class Instagram:
             )
 
             if profile.is_private and not profile.followed_by_viewer:
+                self.logger.debug(
+                    "Private profile - Only profile picture will be downloaded.",
+                )
                 self.loader.download_profilepic_if_new(profile, self.latest_stamps)
                 continue
 
@@ -84,10 +87,6 @@ class Instagram:
                 latest_stamps=self.latest_stamps,
             )
             self.logger.debug("Downloaded timeline for '%s'", user)
-
-            with contextlib.suppress(Exception):
-                self.loader.download_igtv(profile, latest_stamps=self.latest_stamps)
-                self.logger.debug("Downloaded IGTV content for '%s'", user)
 
             if self.download_highlights:
                 with contextlib.suppress(Exception):
@@ -133,7 +132,7 @@ class Instagram:
                 self.logger.error("Unexpected type returned for profile '%s'", username)
                 return None
             self.logger.debug(
-                "Profile retrieved - Username: %s, Followers: %d, Posts: %d",
+                "Profile retrieved - Username: '%s', Followers: %d, Posts: %d",
                 username,
                 profile.followers,
                 profile.mediacount,
@@ -143,7 +142,7 @@ class Instagram:
             self.logger.info("Profile '%s' not found", username)
             return None
         except Exception as e:
-            self.logger.error("Error retrieving profile '%s': %s", username, e)
+            self.logger.error("Error retrieving profile '%s': %s", username, str(e))
             return None
 
     @staticmethod


### PR DESCRIPTION
Introduce user-defined dimensions for removing small images and specify days for old image removal. Update the default cutoff duration for old images from five weeks to four weeks. Improve logging for private profiles and enhance error message formatting.